### PR TITLE
The dart config was setting the 'flutter-run-or-hot-reload' keybind w…

### DIFF
--- a/modules/lang/dart/config.el
+++ b/modules/lang/dart/config.el
@@ -31,7 +31,7 @@
 (use-package! flutter
   :when (featurep! +flutter)
   :defer t
-  :init
+  :config
   (map! :map dart-mode-map
         :localleader
         "r" #'flutter-run-or-hot-reload))


### PR DESCRIPTION
<!-- 

  YOUR PR WILL NOT BE ACCEPTED IF IT DOES NOT MEET THE
  FOLLOWING CRITERIA:

  - [ ] It targets the develop branch
  - [ ] I've searched for similar pull requests and found nothing
  - [ ] This change is NOT in Doom's do-not-PR list: https://doomemacs.org/d/do-not-pr
  - [ ] If I've bumped any packages, I've done so according to https://doomemacs.org/d/how2bump
  - [ ] I've linked any relevant issues and PRs below
  - [ ] All my commit messages are descriptive and distinct

-->

Fixes #0000 <!-- remove if not applicable -->

{{{ Summarize what you've changed HERE and why }}}
The flutter binding in dart.el used init instead of config, so unlike the others, if you changed the localleader key, that one command would keep the prefix "SPC m"